### PR TITLE
properly support utf16le, add sanity check for categories

### DIFF
--- a/src/class-categories/index.ts
+++ b/src/class-categories/index.ts
@@ -197,7 +197,7 @@ export const categoryClassnames: CategoryClassnames = {
 export function getCategoryClasses(classlistMap: DocsClasslistMap): CategoryClasses {
   const categoryClasses: any = {};
   Object.entries(categoryClassnames).forEach(([category, classnames]) => {
-    categoryClasses[category] = classnames.flatMap((classname) => classlistMap[classname]);
+    categoryClasses[category] = classnames.flatMap((classname) => classlistMap[classname]).filter((entry) => entry);
   });
   return (categoryClasses as CategoryClasses);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import util from 'util';
 import { DocsClasslist, DocsClasslistMap } from 'types';
 import { parseItems, parseBuildings, parseRecipes, parseSchematics } from 'parsers';
 import { getCategoryClasses } from 'class-categories';
@@ -8,10 +9,12 @@ function parseDocs(input: Buffer | string) {
   if (Buffer.isBuffer(input)) {
     try {
       // Try utf-16
-      return parseDocsString(input.toString('utf16le', 2));
+      const decoder = new util.TextDecoder('utf-16le');
+      return parseDocsString(decoder.decode(input));
     } catch {
       // if not try utf-8
-      return parseDocsString(input.toString('utf-8'));
+      const decoder = new util.TextDecoder('utf-8');
+      return parseDocsString(decoder.decode(input));
     }
   } else {
     return parseDocsString(input);


### PR DESCRIPTION
Hi there! I've picked up your (absolutely awesome, by the way) yet-another-factory-planner off the Satisfactory discord, and went ahead to look at it, and perhaps tinker and improve. But doing all the deployment steps, I encountered quite some issues on the `npm run parse-docs` step, and so went on to look at the parser first. This PR is basically the result of me finally pushing through the deployment steps for the planner, and having parser working without errors on fresh and unmodified Docs.json.

The changelog is as follows:
- Buffer.toString() doesn't seem to handle BOM correctly (it can handle utf-8 without BOM, but anything else causes issues). TextDecoder does handle all that properly, so used it instead.
- non-existing categories (color gun, ficsmas event stuff, etc) caused undefined values to appear in categoryClasses, and downstream code can't handle that, thus stopping with an error. Added a filter to remove any potential undefined values.